### PR TITLE
Group info

### DIFF
--- a/app/assets/javascripts/all.js
+++ b/app/assets/javascripts/all.js
@@ -1,5 +1,6 @@
 $(document).on("turbolinks:load", function(){
 
+
   function buildHTML(apost){
     var img = apost.image ? `${apost.image}` : "";
     var html = `
@@ -24,6 +25,7 @@ $(document).on("turbolinks:load", function(){
 
     return html
   }
+
 
   // $(document).on("click",".group_radio-btn", function(){
   //   $(".contents").remove();
@@ -52,6 +54,7 @@ $(document).on("turbolinks:load", function(){
         insertHTML = buildHTML(apost);
         $(".contents_three").append(insertHTML);
         // alert(d.title+d.content)
+
       })
     })
     .fail(function(){

--- a/app/assets/javascripts/group.js
+++ b/app/assets/javascripts/group.js
@@ -55,6 +55,7 @@ $(document).on("turbolinks:load", function(){
         $(".contents_three").append(insertHTML);
         // alert(d.title+d.content)
       })
+
     })
     .fail(function(){
       alert('コンテンツの取得に失敗しました');

--- a/app/assets/javascripts/modal.js
+++ b/app/assets/javascripts/modal.js
@@ -82,19 +82,43 @@ $(function(){
 //   });
 // })
 
-// マウスーバー時のみ出現
-$(document).on("turbolinks:load", function(){
-  // var notClicked =  $(".groups label").not(this);
-  $(".group-btn_one label").on("mouseover",function(){
+
+// // フッター グループユーザーをクリックでプロフィールオープン
+$(function(){
+$(".footer_group_user-btn").on("click",function(){
+  // var notClicked =  $(".footer_group_user-btn").not(this);
+  $(this).parent().children("div.prof").toggleClass("hidden")
+  });
+});
+
+// マウスオーバー時のみ出現
+$(function(){
+  $(".group-btn_one label").on("click",function(){
+    var notClicked =  $(".group-btn_one label").not(this);
     // alert("OK")
     $(this).parent().parent().children("div").toggleClass("hidden")
-    // notClicked.parent().parent().children($("div")).addClass("hidden");
+    notClicked.parent().parent().children("div").addClass("hidden");
   });
   // ユーザーポップアップ
-  $(".group-btn_one label").on("mouseleave",function(){
-    $(this).parent().parent().children("div").toggleClass("hidden")
-  });
-})
+  // $(".group-btn_one label").on("mouseleave",function(){
+  //   $(this).parent().parent().children("div").toggleClass("hidden")
+  // });
+});
+
+
+// マウスオーバー時のみ出現
+// $(document).on("turbolinks:load", function(){
+//   // var notClicked =  $(".groups label").not(this);
+//   $(".group-btn_one label").on("click",function(){
+//     // alert("OK")
+//     $(this).parent().parent().children("div").toggleClass("hidden")
+//     // notClicked.parent().parent().children($("div")).addClass("hidden");
+//   });
+//   // ユーザーポップアップ
+//   $(".group-btn_one label").on("mouseleave",function(){
+//     $(this).parent().parent().children("div").toggleClass("hidden")
+//   });
+// })
 
 // // // setTimeout
 // $(document).on("turbolinks:load", function(){

--- a/app/assets/javascripts/modal.js
+++ b/app/assets/javascripts/modal.js
@@ -95,9 +95,13 @@ $(".footer_group_user-btn").on("click",function(){
 $(function(){
   $(".group-btn_one label").on("click",function(){
     var notClicked =  $(".group-btn_one label").not(this);
+    var nowFooter = $(this);
     // alert("OK")
-    $(this).parent().parent().children("div").toggleClass("hidden")
+    $(this).parent().parent().children("div").toggleClass("hidden");
     notClicked.parent().parent().children("div").addClass("hidden");
+    $("#my_all_posts-btn").on("click",function(){
+      nowFooter.parent().parent().children("div").addClass("hidden")
+    })
   });
   // ユーザーポップアップ
   // $(".group-btn_one label").on("mouseleave",function(){

--- a/app/assets/stylesheets/_groups.scss
+++ b/app/assets/stylesheets/_groups.scss
@@ -137,8 +137,17 @@
 
   }
   .prof{
-    position: absolute;
-    top:-30px;
+    background: #ffffffbb;
+    min-width: 140px;
+    max-width: 250px;
+    height: max-content;
+    padding: 4px 7px;
+    margin-right: 12px;
+    position: relative;
+    top: -11px;
+
+    font-size: 12px;
+    border-radius: 3px;
   }
 }
 
@@ -162,9 +171,10 @@
   color: #87bbff;
   font-size:30px;
 
-  &:after{
-    content: "+";
-  }
+  // ユーザー追加 追って実装
+  // &:after{
+  //   content: "+";
+  // }
 }
 
   // span{

--- a/app/assets/stylesheets/_groups.scss
+++ b/app/assets/stylesheets/_groups.scss
@@ -80,43 +80,54 @@
   box-shadow: 0px 1px 1px 1px #dddddd ;
 }
 
+// // // // // // // // //
+// グループユーザー
+//
+
+// カーソルをクリックで、ボタンとBlog一覧の間にグループの情報を表示する
 
 
-// カーソルを合わせると出現する、グループ内のユーザーリスト
 .group_users{
-  position: absolute;
-  margin-top:20px;
-  z-index:500;
+  // position: absolute;
+  position: fixed;
+  // width: calc(76% - 2px);
+  width: 100%;
+  // top: 360px;
+  // left:12%;
+  bottom:0;
+  left:0;
 
+  z-index:500 ;
   // ポップアップのタイトル "GroupUsers"
-  span{
-    background:#fafafa;
+  span.foot_group_users_title{
+    background:#ffffff;
     display:block;
-    padding:0 3px;
+    padding:1px 8px 1px 4px;
     position:absolute;
-    top: - 8px;
-    left: + 13px;
+    top: 30px;
     font-size:11.5px;
-    border-radius: 8px;
+    border-radius:0 8px 8px 0;
+    box-shadow:1px 1px 2px 2px #cccccc;
   }
   &_one{
-    background:#ffffff88;
-    // width: auto;
-    max-width: 300px;
-    height:auto ;
-    padding: 5px 8px;
+    background:#dddddd99;
+    // max-width: 300px;
+    height:76px ;
+    padding: 15px 10px;
     border:solid #dddddd 0.5px;
-    border-radius: 8px;
+    // border-radius: 8px;
     display: flex;
-    flex-direction: column;
+    flex-direction: row;
+    overflow-x: scroll;
 
   }
-  // グループユーザー名
-  & p{
-    background:#87bbffdd ;
 
+  // グループユーザー名
+  & p.footer_group_user-btn{
+    background:#87bbff ;
+    width: auto;
     display: block;
-    margin: 3px 0px 3px 0px;
+    margin: 0px 10px 0px 0px;
     padding: 2px 8px;
     line-height: 25px;
     color:#00000088;
@@ -125,7 +136,61 @@
     border-radius: 15px;
 
   }
-  // & span{
+  .prof{
+    position: absolute;
+    top:-30px;
+  }
+}
+
+.group_add_user{
+  background:#f0f0f0;
+  // position: absolute;
+  position: fixed;
+  // width: calc(76% - 2px);
+  width: 100%;
+  // top: 360px;
+  // left:12%;
+  bottom:0;
+  left:0;
+
+  z-index:600 ;
+}
+
+.add_btn{
+  width: auto;
+  margin-left: 10px;
+  color: #87bbff;
+  font-size:30px;
+
+  &:after{
+    content: "+";
+  }
+}
+
+  // span{
+  //   background:#fafafa;
+  //   display:block;
+  //   padding:0 3px;
+  //   position:absolute;
+  //   top: - 8px;
+  //   left: + 13px;
+  //   font-size:11.5px;
+  //   border-radius: 8px;
+  // }
+  // &_one{
+  //   background:#ffffff88;
+  //   // width: auto;
+  //   max-width: 300px;
+  //   height:auto ;
+  //   padding: 5px 8px;
+  //   border:solid #dddddd 0.5px;
+  //   border-radius: 8px;
+  //   display: flex;
+  //   flex-direction: column;
+
+  // }
+  // // グループユーザー名
+  // & p{
   //   background:#87bbffdd ;
 
   //   display: block;
@@ -136,8 +201,10 @@
   //   font-size:13px;
   //   white-space: nowrap;
   //   border-radius: 15px;
+
   // }
-}
+
+
 
 
 // // //

--- a/app/assets/stylesheets/_post.scss
+++ b/app/assets/stylesheets/_post.scss
@@ -1,4 +1,9 @@
 
+  .contents_one{
+    margin-top: 80px;
+  }
+
+
 // // // // // // // // // // // // // // // // // //
 // // // // // // // // // // // // // // // // // //
 // スマホ
@@ -12,7 +17,6 @@
   .contents_two{
     width:100%;
     height:calc(100% - 80px);
-
   }
   .contents_three{
     width:100%;

--- a/app/views/posts/index.html.haml
+++ b/app/views/posts/index.html.haml
@@ -154,7 +154,7 @@
           選択したグループの投稿を表示します
 
         = radio_button_tag "groups","all",type:"radio", class:"group_name"
-        = label_tag "groups_all", "#{current_user.name}の投稿", class:"group_name"
+        = label_tag "groups_all", "#{current_user.name}の投稿", class:"group_name",id:"my_all_posts-btn"
 
         - current_user.groups.each do |group|
           .group-btn_one

--- a/app/views/posts/index.html.haml
+++ b/app/views/posts/index.html.haml
@@ -161,15 +161,29 @@
             = link_to root_path, class: "hoge", id:"group_#{group.id}" do
               = radio_button_tag "groups","#{group.group_name}",type:"radio", class:"group_name"
               = label_tag "groups_#{group.group_name}", "#{group.group_name}", class:"group_name"
+
             .group_users.hidden
-              %span
-                GroupUsers
-              .group_users_one
-                - group.group_users.each do |user|
-                  %p
-                    = user.user.name
-                  .prof.hidden
-                    = user.user.profile
+              = form_for "", url: "groups/update", method: :patch do |f|
+                %h3
+                  = f.text_field :group_name, value:"#{group.group_name}"
+                = f.submit "グループ名の変更を保存", id:"group_name-edit_submit"
+
+                %span{class:"foot_group_users_title"}
+                  グループメンバー
+                .group_users_one
+                  - group.group_users.each do |user|
+                    = link_to "", url: "group_users/update", method: :delete do
+                      -# .del-user
+                      -#   [×]
+                    %p{class:"footer_group_user-btn",id:"group_user_#{user.user.name} group_user_#{user.user.id}"}
+                      = user.user.name
+                    -# モーダルで出す
+                    .prof.hidden
+                      = user.user.profile
+                    .group_add_user.hidden
+                      %p{id:"group_add_#{user.user.id}"}
+                      = user.user.name
+                  .add_btn
 
 
     -# 投稿一覧 タイル表示

--- a/app/views/posts/index.json.jbuilder
+++ b/app/views/posts/index.json.jbuilder
@@ -6,6 +6,7 @@ json.array! @group_posts do |post|
   json.date post.updated_at.strftime("%Y年%m月%d日 %H時%M分")
   json.content post.content
   json.image post.image.url
+
 end
 
 json.array! @user_posts do |apost|
@@ -15,5 +16,6 @@ json.array! @user_posts do |apost|
   json.date apost.updated_at.strftime("%Y年%m月%d日 %H時%M分")
   json.content apost.content
   json.image apost.image.url
+
 end
 


### PR DESCRIPTION
# 実装内容

（グループ・ボタンをクリックで、）
グループユーザー名とプロフィールを、クリックで展開されるフッターに表示。

# なぜ変更したか

UI/UXの考え方を踏まえた結果の改善。

以前のデザインでは、グループユーザー名が、スマホで見たときにボタンが小さすぎた。
ユーザー名をクリックしてプロフィールの展開を考えていたが、いささか操作性に欠けた。
見た目も悪かったし、その後の機能追加に対する拡張性も考えて、こうした。